### PR TITLE
Create search bar - Search logic on iTunes screen

### DIFF
--- a/SwiftUIExamples.xcodeproj/project.pbxproj
+++ b/SwiftUIExamples.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D801DB2026123AE500844A96 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D801DB1F26123AE500844A96 /* Environment.swift */; };
+		D801DB2026123AE500844A96 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D801DB1F26123AE500844A96 /* AppEnvironment.swift */; };
 		D801DB2626123E6300844A96 /* Publishers+Decoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D801DB2526123E6300844A96 /* Publishers+Decoding.swift */; };
 		D801DB2E26123F6800844A96 /* URLSession+DataTaskPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D801DB2D26123F6800844A96 /* URLSession+DataTaskPublisher.swift */; };
 		D801DB332612448E00844A96 /* URLHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = D801DB322612448E00844A96 /* URLHost.swift */; };
@@ -15,6 +15,7 @@
 		D8709D1026235AEA00A9C442 /* LogoImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709D0F26235AEA00A9C442 /* LogoImage.swift */; };
 		D8709D1526235F5900A9C442 /* CommonImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709D1426235F5900A9C442 /* CommonImage.swift */; };
 		D8709D1B2623710000A9C442 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = D8709D1A2623710000A9C442 /* Kingfisher */; };
+		D8709D2426263A2200A9C442 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709D2326263A2200A9C442 /* SearchBar.swift */; };
 		D87825A126235463003AF99A /* VTitleAndDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87825A026235463003AF99A /* VTitleAndDescriptionView.swift */; };
 		D87ADA3E26062EEC00123975 /* SwiftUIExamplesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87ADA3D26062EEC00123975 /* SwiftUIExamplesApp.swift */; };
 		D87ADA4026062EEC00123975 /* MainListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87ADA3F26062EEC00123975 /* MainListView.swift */; };
@@ -35,7 +36,6 @@
 		D8889EF32618DDDE00049C2C /* ItunesSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8889EF22618DDDE00049C2C /* ItunesSearchView.swift */; };
 		D8889EFA2618DFC600049C2C /* ItunesSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8889EF92618DFC600049C2C /* ItunesSearchViewModel.swift */; };
 		D8894F2C2611F66E00737855 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8894F2B2611F66E00737855 /* Endpoint.swift */; };
-		D8BBCFF92611EEED00A9A6FE /* yelp_search_example.json in Resources */ = {isa = PBXBuildFile; fileRef = D8BBCFF82611EEED00A9A6FE /* yelp_search_example.json */; };
 		D8BBCFFE2611EF3200A9A6FE /* ItunesSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BBCFFD2611EF3200A9A6FE /* ItunesSearch.swift */; };
 		D8BBD0042611F1F800A9A6FE /* SearchResultsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BBD0032611F1F800A9A6FE /* SearchResultsRepository.swift */; };
 		D8E0F0F8261B87D0001D403E /* RatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E0F0F7261B87D0001D403E /* RatingView.swift */; };
@@ -59,13 +59,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		D801DB1F26123AE500844A96 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		D801DB1F26123AE500844A96 /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		D801DB2526123E6300844A96 /* Publishers+Decoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publishers+Decoding.swift"; sourceTree = "<group>"; };
 		D801DB2D26123F6800844A96 /* URLSession+DataTaskPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+DataTaskPublisher.swift"; sourceTree = "<group>"; };
 		D801DB322612448E00844A96 /* URLHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHost.swift; sourceTree = "<group>"; };
 		D801DB372612510D00844A96 /* URLRequest+Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Networking.swift"; sourceTree = "<group>"; };
 		D8709D0F26235AEA00A9C442 /* LogoImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoImage.swift; sourceTree = "<group>"; };
 		D8709D1426235F5900A9C442 /* CommonImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonImage.swift; sourceTree = "<group>"; };
+		D8709D2326263A2200A9C442 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		D87825A026235463003AF99A /* VTitleAndDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VTitleAndDescriptionView.swift; sourceTree = "<group>"; };
 		D87ADA3A26062EEC00123975 /* SwiftUIExamples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIExamples.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D87ADA3D26062EEC00123975 /* SwiftUIExamplesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExamplesApp.swift; sourceTree = "<group>"; };
@@ -130,6 +131,23 @@
 				D801DB2D26123F6800844A96 /* URLSession+DataTaskPublisher.swift */,
 			);
 			name = Publishers;
+			sourceTree = "<group>";
+		};
+		D8709D222626390300A9C442 /* SearchBar */ = {
+			isa = PBXGroup;
+			children = (
+				D8709D2326263A2200A9C442 /* SearchBar.swift */,
+			);
+			name = SearchBar;
+			sourceTree = "<group>";
+		};
+		D8709D2826263A8A00A9C442 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				D87ADA4626062EF200123975 /* Info.plist */,
+				D87ADA4126062EF200123975 /* Assets.xcassets */,
+			);
+			name = Resources;
 			sourceTree = "<group>";
 		};
 		D8782596261E1FE5003AF99A /* Screens */ = {
@@ -198,8 +216,7 @@
 				D8889EF82618DFA100049C2C /* Views */,
 				D87ADA3F26062EEC00123975 /* MainListView.swift */,
 				D87ADA3D26062EEC00123975 /* SwiftUIExamplesApp.swift */,
-				D87ADA4126062EF200123975 /* Assets.xcassets */,
-				D87ADA4626062EF200123975 /* Info.plist */,
+				D8709D2826263A8A00A9C442 /* Resources */,
 				D87ADA4326062EF200123975 /* Preview Content */,
 			);
 			path = SwiftUIExamples;
@@ -266,7 +283,7 @@
 			isa = PBXGroup;
 			children = (
 				D8889E0A26136E9100049C2C /* Configuration.swift */,
-				D801DB1F26123AE500844A96 /* Environment.swift */,
+				D801DB1F26123AE500844A96 /* AppEnvironment.swift */,
 			);
 			name = Configuration;
 			sourceTree = "<group>";
@@ -274,6 +291,7 @@
 		D8889EF82618DFA100049C2C /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				D8709D222626390300A9C442 /* SearchBar */,
 				D8889E772614C2E800049C2C /* AppRow.swift */,
 				D8E0F0F7261B87D0001D403E /* RatingView.swift */,
 				D87825A026235463003AF99A /* VTitleAndDescriptionView.swift */,
@@ -450,6 +468,7 @@
 				D87ADA8826063DCC00123975 /* ForEachExtensions.swift in Sources */,
 				D8709D1526235F5900A9C442 /* CommonImage.swift in Sources */,
 				D87825A126235463003AF99A /* VTitleAndDescriptionView.swift in Sources */,
+				D8709D2426263A2200A9C442 /* SearchBar.swift in Sources */,
 				D87ADA6C2606314A00123975 /* MenuItem.swift in Sources */,
 				D801DB382612510D00844A96 /* URLRequest+Networking.swift in Sources */,
 				D8889DF726136CB800049C2C /* NetworkingClient.swift in Sources */,
@@ -460,7 +479,7 @@
 				D8BBCFFE2611EF3200A9A6FE /* ItunesSearch.swift in Sources */,
 				D8889DE62613658B00049C2C /* NetworkingConstants.swift in Sources */,
 				D801DB332612448E00844A96 /* URLHost.swift in Sources */,
-				D801DB2026123AE500844A96 /* Environment.swift in Sources */,
+				D801DB2026123AE500844A96 /* AppEnvironment.swift in Sources */,
 				D801DB2626123E6300844A96 /* Publishers+Decoding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftUIExamples.xcodeproj/project.pbxproj
+++ b/SwiftUIExamples.xcodeproj/project.pbxproj
@@ -16,6 +16,11 @@
 		D8709D1526235F5900A9C442 /* CommonImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709D1426235F5900A9C442 /* CommonImage.swift */; };
 		D8709D1B2623710000A9C442 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = D8709D1A2623710000A9C442 /* Kingfisher */; };
 		D8709D2426263A2200A9C442 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709D2326263A2200A9C442 /* SearchBar.swift */; };
+		D8709D3126277C7D00A9C442 /* RestrictSizeCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709D3026277C7C00A9C442 /* RestrictSizeCategory.swift */; };
+		D8709D3926277CC100A9C442 /* BindingExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709D3826277CC100A9C442 /* BindingExtensions.swift */; };
+		D8709D3F262791B000A9C442 /* UIApplicationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709D3E262791B000A9C442 /* UIApplicationExtensions.swift */; };
+		D8709D48262791F700A9C442 /* ScrollViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709D47262791F700A9C442 /* ScrollViewExtensions.swift */; };
+		D8709D502627921000A9C442 /* ViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709D4F2627921000A9C442 /* ViewExtensions.swift */; };
 		D87825A126235463003AF99A /* VTitleAndDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87825A026235463003AF99A /* VTitleAndDescriptionView.swift */; };
 		D87ADA3E26062EEC00123975 /* SwiftUIExamplesApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87ADA3D26062EEC00123975 /* SwiftUIExamplesApp.swift */; };
 		D87ADA4026062EEC00123975 /* MainListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87ADA3F26062EEC00123975 /* MainListView.swift */; };
@@ -67,6 +72,11 @@
 		D8709D0F26235AEA00A9C442 /* LogoImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoImage.swift; sourceTree = "<group>"; };
 		D8709D1426235F5900A9C442 /* CommonImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonImage.swift; sourceTree = "<group>"; };
 		D8709D2326263A2200A9C442 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
+		D8709D3026277C7C00A9C442 /* RestrictSizeCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestrictSizeCategory.swift; sourceTree = "<group>"; };
+		D8709D3826277CC100A9C442 /* BindingExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingExtensions.swift; sourceTree = "<group>"; };
+		D8709D3E262791B000A9C442 /* UIApplicationExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationExtensions.swift; sourceTree = "<group>"; };
+		D8709D47262791F700A9C442 /* ScrollViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewExtensions.swift; sourceTree = "<group>"; };
+		D8709D4F2627921000A9C442 /* ViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtensions.swift; sourceTree = "<group>"; };
 		D87825A026235463003AF99A /* VTitleAndDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VTitleAndDescriptionView.swift; sourceTree = "<group>"; };
 		D87ADA3A26062EEC00123975 /* SwiftUIExamples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIExamples.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D87ADA3D26062EEC00123975 /* SwiftUIExamplesApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExamplesApp.swift; sourceTree = "<group>"; };
@@ -148,6 +158,33 @@
 				D87ADA4126062EF200123975 /* Assets.xcassets */,
 			);
 			name = Resources;
+			sourceTree = "<group>";
+		};
+		D8709D2F26277C6600A9C442 /* View Modifiers */ = {
+			isa = PBXGroup;
+			children = (
+				D8709D3026277C7C00A9C442 /* RestrictSizeCategory.swift */,
+			);
+			name = "View Modifiers";
+			sourceTree = "<group>";
+		};
+		D8709D3D2627918700A9C442 /* UIViewExtensions */ = {
+			isa = PBXGroup;
+			children = (
+				D8709D3E262791B000A9C442 /* UIApplicationExtensions.swift */,
+			);
+			name = UIViewExtensions;
+			sourceTree = "<group>";
+		};
+		D8709D46262791DF00A9C442 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				D87ADA8726063DCC00123975 /* ForEachExtensions.swift */,
+				D8709D3826277CC100A9C442 /* BindingExtensions.swift */,
+				D8709D47262791F700A9C442 /* ScrollViewExtensions.swift */,
+				D8709D4F2627921000A9C442 /* ViewExtensions.swift */,
+			);
+			name = Extensions;
 			sourceTree = "<group>";
 		};
 		D8782596261E1FE5003AF99A /* Screens */ = {
@@ -260,7 +297,7 @@
 		D87ADA8F26063DDB00123975 /* SwiftUI Utils */ = {
 			isa = PBXGroup;
 			children = (
-				D87ADA8726063DCC00123975 /* ForEachExtensions.swift */,
+				D8709D46262791DF00A9C442 /* Extensions */,
 				D87ADA9026063E1F00123975 /* ContentPreview.swift */,
 			);
 			name = "SwiftUI Utils";
@@ -291,6 +328,7 @@
 		D8889EF82618DFA100049C2C /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				D8709D2F26277C6600A9C442 /* View Modifiers */,
 				D8709D222626390300A9C442 /* SearchBar */,
 				D8889E772614C2E800049C2C /* AppRow.swift */,
 				D8E0F0F7261B87D0001D403E /* RatingView.swift */,
@@ -314,6 +352,7 @@
 		D8BBCFF62611EEC600A9A6FE /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				D8709D3D2627918700A9C442 /* UIViewExtensions */,
 				D8889DF526136A9000049C2C /* Networking */,
 			);
 			name = Core;
@@ -455,11 +494,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				D8889EFA2618DFC600049C2C /* ItunesSearchViewModel.swift in Sources */,
+				D8709D48262791F700A9C442 /* ScrollViewExtensions.swift in Sources */,
 				D8889DEB2613698A00049C2C /* EndpointType.swift in Sources */,
 				D87ADA9126063E1F00123975 /* ContentPreview.swift in Sources */,
 				D8889E0226136E4200049C2C /* NetworkingErrors.swift in Sources */,
 				D8889E0B26136E9100049C2C /* Configuration.swift in Sources */,
 				D8894F2C2611F66E00737855 /* Endpoint.swift in Sources */,
+				D8709D3F262791B000A9C442 /* UIApplicationExtensions.swift in Sources */,
 				D801DB2E26123F6800844A96 /* URLSession+DataTaskPublisher.swift in Sources */,
 				D8709D1026235AEA00A9C442 /* LogoImage.swift in Sources */,
 				D8E0F0F8261B87D0001D403E /* RatingView.swift in Sources */,
@@ -471,11 +512,14 @@
 				D8709D2426263A2200A9C442 /* SearchBar.swift in Sources */,
 				D87ADA6C2606314A00123975 /* MenuItem.swift in Sources */,
 				D801DB382612510D00844A96 /* URLRequest+Networking.swift in Sources */,
+				D8709D3926277CC100A9C442 /* BindingExtensions.swift in Sources */,
 				D8889DF726136CB800049C2C /* NetworkingClient.swift in Sources */,
+				D8709D3126277C7D00A9C442 /* RestrictSizeCategory.swift in Sources */,
 				D87ADA7F260639C600123975 /* MenuRow.swift in Sources */,
 				D8BBD0042611F1F800A9A6FE /* SearchResultsRepository.swift in Sources */,
 				D87ADA4026062EEC00123975 /* MainListView.swift in Sources */,
 				D87ADA3E26062EEC00123975 /* SwiftUIExamplesApp.swift in Sources */,
+				D8709D502627921000A9C442 /* ViewExtensions.swift in Sources */,
 				D8BBCFFE2611EF3200A9A6FE /* ItunesSearch.swift in Sources */,
 				D8889DE62613658B00049C2C /* NetworkingConstants.swift in Sources */,
 				D801DB332612448E00844A96 /* URLHost.swift in Sources */,

--- a/SwiftUIExamples/AppEnvironment.swift
+++ b/SwiftUIExamples/AppEnvironment.swift
@@ -2,9 +2,9 @@
 
 import Foundation
 
-// protocol Environment and different Services implementation
+// protocol AppEnvironment and different Services implementation
 
-enum Environment: String {
+enum AppEnvironment: String {
     case production
     
     var host: URLHost {
@@ -13,7 +13,7 @@ enum Environment: String {
 }
 
 // MARK: Custom String Convertible
-extension Environment : CustomStringConvertible, CustomDebugStringConvertible {
+extension AppEnvironment : CustomStringConvertible, CustomDebugStringConvertible {
     var description: String {
         "PRODUCTION"
     }

--- a/SwiftUIExamples/AppRow.swift
+++ b/SwiftUIExamples/AppRow.swift
@@ -6,53 +6,38 @@ import Combine
 struct AppRow: View {
     @State var item: SearchItem
     
+    var ratingStack: some View {
+        HStack(alignment: .center, spacing: 6) {
+            RatingView(rating: Float(item.averageUserRating))
+                .frame(height: 12)
+            Text(String(format: "(%.2f)", item.averageUserRating))
+                .font(.caption2)
+                .foregroundColor(Color(UIColor.secondaryLabel))
+        }
+    }
+    
     var body: some View {
-        VStack(alignment: .leading, spacing: 24) {
+        VStack(alignment: .leading) {
             HStack(alignment: .top) {
                 LogoImage(url: self.item.artworkUrl100)
                 VStack(alignment: .leading, spacing: 8) {
                     VTitleAndDescriptionView(name: item.trackName, description: item.description)
-                    HStack(alignment: .center, spacing: 6) {
-                        RatingView(rating: Float(item.averageUserRating))
-                            .frame(height: 12)
-                        Text(String(format: "%.2f", item.averageUserRating))
-                            .font(.caption2)
-                            .foregroundColor(Color(UIColor.secondaryLabel))
-                    }
+                    ratingStack
                 }
-                .layoutPriority(1)
                 Spacer()
             }
             
-//            buildImageColumns(maximum: 3)
-//                .frame(height: 220)
-            
-            LazyVGrid(columns: [GridItem(.flexible()),
-                             GridItem(.flexible()),
-                             GridItem(.flexible())],
-                      alignment: .center, spacing: 12) {
-                CommonImage(url: self.item.screenshotUrls[0])
-                    .clipShape(RoundedRectangle(cornerRadius: 5))
-                    .frame(height: 220)
-                CommonImage(url: self.item.screenshotUrls[1])
-                    .clipShape(RoundedRectangle(cornerRadius: 5))
-                    .frame(height: 220)
-                CommonImage(url: self.item.screenshotUrls[2])
-                    .clipShape(RoundedRectangle(cornerRadius: 5))
-                    .frame(height: 220)
-            }
-            .font(.body)
-//            .animation(.easeIn)
+            buildImageColumns(maximum: 3, height: 260)
         }
         .padding()
         .background(Color(UIColor.systemBackground))
         .clipShape(RoundedRectangle(cornerRadius: 25.0))
     }
     
-    func buildImageColumns(maximum: Int) -> some View {
+    private func buildImageColumns(maximum: Int, height: CGFloat) -> some View {
         var urls = self.item.screenshotUrls
-        if self.item.screenshotUrls.count >= maximum {
-            urls = Array(self.item.screenshotUrls[1...maximum])
+        if self.item.screenshotUrls.count > maximum {
+            urls = Array(self.item.screenshotUrls[0..<maximum])
         }
         
         var columns: [GridItem] = []
@@ -60,14 +45,14 @@ struct AppRow: View {
         for url in urls {
             columns.append(GridItem(.flexible()))
             let image: CommonImage = CommonImage(url: url)
-//                .clipShape(RoundedRectangle(cornerRadius: 5))
             items.append(image)
         }
         return LazyVGrid(columns: columns,
                          alignment: .center, spacing: 12) {
             ForEach(items, id: \.url) { item in
                 item
-                    .frame(height: 220)
+                    .frame(height: height)
+                    .clipShape(RoundedRectangle(cornerRadius: 5))
             }
         }
     }

--- a/SwiftUIExamples/BindingExtensions.swift
+++ b/SwiftUIExamples/BindingExtensions.swift
@@ -1,0 +1,12 @@
+// Created by Cantero on 14/04/2021.
+
+import SwiftUI
+
+#if DEBUG
+extension Binding {
+    static func mock(_ value: Value) -> Self {
+        var value = value
+        return Binding(get: { value }, set: { value = $0 })
+    }
+}
+#endif

--- a/SwiftUIExamples/CommonImage.swift
+++ b/SwiftUIExamples/CommonImage.swift
@@ -2,8 +2,6 @@
 import SwiftUI
 import Kingfisher
 
-var cache: Set<String> = .init()
-
 struct CommonImage: View {
     var url: URL?
     

--- a/SwiftUIExamples/Configuration.swift
+++ b/SwiftUIExamples/Configuration.swift
@@ -8,10 +8,10 @@ struct UserDefaultsKey {
 
 struct Configuration {
     
-    static var environment: Environment = {
+    static var environment: AppEnvironment = {
         guard let configuration = Bundle.main.object(forInfoDictionaryKey: UserDefaultsKey.configuration) as? String,
-            var env = Environment(rawValue: configuration)
-            else { return Environment.production }
+            var env = AppEnvironment(rawValue: configuration)
+            else { return AppEnvironment.production }
         
         return env
     }()

--- a/SwiftUIExamples/ItunesSearch.swift
+++ b/SwiftUIExamples/ItunesSearch.swift
@@ -2,8 +2,6 @@
 
 import Foundation
 
-typealias NetworkModel = Identifiable & Decodable & Hashable
-
 struct SearchResult: Decodable {
     var resultCount: Int
     var results: [SearchItem]

--- a/SwiftUIExamples/ItunesSearchView.swift
+++ b/SwiftUIExamples/ItunesSearchView.swift
@@ -7,18 +7,22 @@ struct ItunesSearchView: View {
     @ObservedObject var viewModel: ItunesSearchViewModel = ItunesSearchViewModel()
     
     var body: some View {
-        cache = .init()
-        return ScrollView {
-            LazyVStack {
-                ForEach(viewModel.models) { item in
-                    AppRow(item: item)
-                }
+        VStack {
+            SearchBar(text: $viewModel.searchText) {
+                viewModel.cancelSearch()
             }
+            ScrollView {
+                LazyVStack {
+                    ForEach(viewModel.models) { item in
+                        AppRow(item: item)
+                    }
+                }
+                .animation(.easeIn(duration: 0.3))
+            }
+            .dismissKeyboardOnDrag()
+            .dismissKeyboardOnTap()
         }
         .navigationTitle("Itunes Search")
-        .onAppear {
-            viewModel.request()
-        }
     }
 }
 

--- a/SwiftUIExamples/NetworkingClient.swift
+++ b/SwiftUIExamples/NetworkingClient.swift
@@ -3,7 +3,13 @@
 import Foundation
 import Combine
 
-struct NetworkingClient {
+typealias NetworkModel = Identifiable & Decodable & Hashable
+
+protocol APIClient {
+    func request<K, R>(endpoint: Endpoint<K, R>, using requestData: K.RequestData) -> AnyPublisher<R, Error>
+}
+
+struct NetworkingClient: APIClient {
     var urlSession = URLSession.shared
     
     func request<K, R>(endpoint: Endpoint<K, R>, using requestData: K.RequestData) -> AnyPublisher<R, Error> {

--- a/SwiftUIExamples/Publishers+Decoding.swift
+++ b/SwiftUIExamples/Publishers+Decoding.swift
@@ -4,7 +4,7 @@ import Foundation
 import Combine
 
 extension JSONDecoder {
-    static let snakeCaseConverting: JSONDecoder = {
+    static let useDefaultKeys: JSONDecoder = {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .useDefaultKeys
         decoder.dateDecodingStrategy = .iso8601
@@ -15,7 +15,7 @@ extension JSONDecoder {
 extension Publisher where Output == Data {
     
     func decode<T: Decodable>(as type: T.Type = T.self,
-                              using decoder: JSONDecoder = .snakeCaseConverting) -> Publishers.Decode<Self, T, JSONDecoder> {
+                              using decoder: JSONDecoder = .useDefaultKeys) -> Publishers.Decode<Self, T, JSONDecoder> {
         decode(type: type, decoder: decoder)
     }
 }

--- a/SwiftUIExamples/RatingView.swift
+++ b/SwiftUIExamples/RatingView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 private struct Constants {
     static let color = Color.orange
     static let maxStarCount = 5
+    static let spacing: CGFloat = 4
 }
 
 private enum Star: String {
@@ -16,6 +17,7 @@ private enum Star: String {
 
 struct RatingView: View {
     let rating: Float
+    var spacing = Constants.spacing
     var color = Constants.color
     var maxNumOfStars = Constants.maxStarCount
     
@@ -30,7 +32,7 @@ struct RatingView: View {
     }
     
     var body: some View {
-        HStack {
+        HStack(spacing: spacing) {
             addStars(count: fullStarCount, starKind: .full)
             addStars(count: halfStarCount, starKind: .halfFull)
             addStars(count: emptyStarCount, starKind: .empty)

--- a/SwiftUIExamples/RestrictSizeCategory.swift
+++ b/SwiftUIExamples/RestrictSizeCategory.swift
@@ -1,0 +1,24 @@
+// Created by Cantero on 14/04/2021.
+
+import SwiftUI
+
+fileprivate struct RestrictSizeCategory: ViewModifier {
+    @Environment(\.sizeCategory) var sizeCategory
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+            if sizeCategory > ContentSizeCategory.extraExtraExtraLarge {
+                content.transformEnvironment(\.sizeCategory) { value in
+                    value = ContentSizeCategory.extraExtraExtraLarge
+                }
+            } else {
+                content
+            }
+    }
+}
+
+extension View {
+    func restrictSizeCategory() -> some View {
+        return modifier(RestrictSizeCategory())
+    }
+}

--- a/SwiftUIExamples/ScrollViewExtensions.swift
+++ b/SwiftUIExamples/ScrollViewExtensions.swift
@@ -1,0 +1,12 @@
+// Created by Cantero on 14/04/2021.
+
+import SwiftUI
+
+extension ScrollView {
+    func dismissKeyboardOnDrag() -> some View {
+        self.gesture(DragGesture()
+                        .onChanged { _ in
+                            UIApplication.shared.endEditing()
+                        })
+    }
+}

--- a/SwiftUIExamples/SearchBar.swift
+++ b/SwiftUIExamples/SearchBar.swift
@@ -1,0 +1,91 @@
+// Created by Cantero on 13/04/2021.
+
+import SwiftUI
+
+fileprivate struct RestrictSizeCategory: ViewModifier {
+    @Environment(\.sizeCategory) var sizeCategory
+
+    func body(content: Content) -> some View {
+        Group {
+            if sizeCategory > ContentSizeCategory.extraExtraExtraLarge {
+                content.transformEnvironment(\.sizeCategory) { value in
+                    value = ContentSizeCategory.extraExtraExtraLarge
+                }
+            } else {
+                content
+            }
+        }
+    }
+}
+
+extension View {
+    func restrictSizeCategory() -> some View {
+        return modifier(RestrictSizeCategory())
+    }
+}
+
+// MARK:-  View
+
+struct SearchBar: View {
+    @Binding var text: String
+    @State private var isEditing: Bool = false
+    
+    var body: some View {
+        HStack {
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.gray)
+                    .padding(.leading, 8)
+                    .restrictSizeCategory()
+                
+                TextField("Search ...", text: $text)
+
+                if isEditing {
+                    Button(action: {
+                        text = ""
+                    }) {
+                        Image(systemName: "multiply.circle.fill")
+                            .foregroundColor(.gray)
+                            .padding(.trailing, 8)
+                    }
+                    .restrictSizeCategory()
+                    .animation(.easeIn)
+                }
+            }
+            .padding(7)
+            .background(Color(UIColor.systemGray5))
+            .cornerRadius(8)
+            .padding(.horizontal)
+            .onTapGesture {
+                isEditing = true
+            }
+            .animation(.default)
+            
+            if isEditing {
+                Button("Cancel") {
+                    text = ""
+                    isEditing = false
+                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                }
+                .padding(.trailing)
+                .transition(.move(edge: .trailing))
+                .animation(.default)
+            }
+        }
+    }
+}
+
+struct SearchBar_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchBar(text: .mock(""))
+            .frame(width: 375)
+            .previewAsComponent()
+    }
+}
+
+extension Binding {
+    static func mock(_ value: Value) -> Self {
+        var value = value
+        return Binding(get: { value }, set: { value = $0 })
+    }
+}

--- a/SwiftUIExamples/SearchResultsRepository.swift
+++ b/SwiftUIExamples/SearchResultsRepository.swift
@@ -18,10 +18,9 @@ protocol SearchResultsRepositoryProtocol {
 }
 
 struct SearchResultsRepository: SearchResultsRepositoryProtocol {
-    
-    var urlSession = URLSession.shared
+    var client: APIClient = NetworkingClient()
     
     func loadResults(matching query: String) -> AnyPublisher<SearchResult, Error> {
-        urlSession.publisher(forEndpoint: .search(matching: query), using: ())
+        client.request(endpoint: .search(matching: query), using: ())
     }
 }

--- a/SwiftUIExamples/UIApplicationExtensions.swift
+++ b/SwiftUIExamples/UIApplicationExtensions.swift
@@ -1,0 +1,9 @@
+// Created by Cantero on 14/04/2021.
+
+import UIKit
+
+extension UIApplication {
+    func endEditing() {
+        sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}

--- a/SwiftUIExamples/ViewExtensions.swift
+++ b/SwiftUIExamples/ViewExtensions.swift
@@ -1,0 +1,11 @@
+// Created by Cantero on 14/04/2021.
+
+import SwiftUI
+
+extension View {
+    func dismissKeyboardOnTap() -> some View {
+        self.onTapGesture {
+            UIApplication.shared.endEditing()
+        }
+    }
+}


### PR DESCRIPTION
## What's this PR doing?

* Creates a Search Bar reusable view.
* 🤠 Some boy-scout by setting correct dependencies on the repo
* Integrate Search bar and search logic on iTunes Screen:

    - Change animation on Search bar
    - Hide Keyboard on cancel and when user taps or scrolls.
    - Restrict maximum size for environment's size category on images.
    - Delay search on 0.3 seconds to avoid overloading servers
